### PR TITLE
Fail on `twine check` warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Build and check
       run: |
         rm -rf dist/ && python -m build
-        twine check dist/*
+        twine check --strict dist/*
     - name: Publish
       run: |
         twine upload dist/*


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos